### PR TITLE
Update template for Candy Machine V2

### DIFF
--- a/app/src/CandyMachine/connection.js
+++ b/app/src/CandyMachine/connection.js
@@ -1,0 +1,513 @@
+import { Transaction } from '@solana/web3.js';
+
+import { WalletNotConnectedError } from '@solana/wallet-adapter-base';
+
+export const getErrorForTransaction = async (
+  connection,
+  txid
+) => {
+  // wait for all confirmation before geting transaction
+  await connection.confirmTransaction(txid, 'max');
+
+  const tx = await connection.getParsedConfirmedTransaction(txid);
+
+  const errors = [];
+  if (tx?.meta && tx.meta.logMessages) {
+    tx.meta.logMessages.forEach(log => {
+      const regex = /Error: (.*)/gm;
+      let m;
+      while ((m = regex.exec(log)) !== null) {
+        // This is necessary to avoid infinite loops with zero-width matches
+        if (m.index === regex.lastIndex) {
+          regex.lastIndex++;
+        }
+
+        if (m.length > 1) {
+          errors.push(m[1]);
+        }
+      }
+    });
+  }
+
+  return errors;
+};
+
+
+export async function sendTransactionsWithManualRetry(
+  connection,
+  wallet,
+  instructions,
+  signers,
+){
+  let stopPoint = 0;
+  let tries = 0;
+  let lastInstructionsLength = null;
+  let toRemoveSigners = {};
+  instructions = instructions.filter((instr, i) => {
+    if (instr.length > 0) {
+      return true;
+    } else {
+      toRemoveSigners[i] = true;
+      return false;
+    }
+  });
+  let ids = [];
+  let filteredSigners = signers.filter((_, i) => !toRemoveSigners[i]);
+
+  while (stopPoint < instructions.length && tries < 3) {
+    instructions = instructions.slice(stopPoint, instructions.length);
+    filteredSigners = filteredSigners.slice(stopPoint, filteredSigners.length);
+
+    if (instructions.length === lastInstructionsLength) tries = tries + 1;
+    else tries = 0;
+
+    try {
+      if (instructions.length === 1) {
+        const id = await sendTransactionWithRetry(
+          connection,
+          wallet,
+          instructions[0],
+          filteredSigners[0],
+          'single',
+        );
+        ids.push(id.txid);
+        stopPoint = 1;
+      } else {
+        const { txs } = await sendTransactions(
+          connection,
+          wallet,
+          instructions,
+          filteredSigners,
+          'StopOnFailure',
+          'single',
+        );
+        ids = ids.concat(txs.map(t => t.txid));
+      }
+    } catch (e) {
+      console.error(e);
+    }
+    console.log(
+      'Died on ',
+      stopPoint,
+      'retrying from instruction',
+      instructions[stopPoint],
+      'instructions length is',
+      instructions.length,
+    );
+    lastInstructionsLength = instructions.length;
+  }
+
+  return ids;
+}
+
+export const sendTransactions = async (
+  connection,
+  wallet,
+  instructionSet,
+  signersSet,
+  sequenceType = 'Parallel',
+  commitment = 'singleGossip',
+  successCallback = (txid, ind) => {},
+  failCallback = (txid, ind) => false,
+  block,
+) => {
+  if (!wallet.publicKey) throw new WalletNotConnectedError();
+
+  const unsignedTxns = [];
+
+  if (!block) {
+    block = await connection.getRecentBlockhash(commitment);
+  }
+
+  for (let i = 0; i < instructionSet.length; i++) {
+    const instructions = instructionSet[i];
+    const signers = signersSet[i];
+
+    if (instructions.length === 0) {
+      continue;
+    }
+
+    let transaction = new Transaction();
+    instructions.forEach(instruction => transaction.add(instruction));
+    transaction.recentBlockhash = block.blockhash;
+    transaction.setSigners(
+      // fee payed by the wallet owner
+      wallet.publicKey,
+      ...signers.map(s => s.publicKey),
+    );
+
+    if (signers.length > 0) {
+      transaction.partialSign(...signers);
+    }
+
+    unsignedTxns.push(transaction);
+  }
+
+  const signedTxns = await wallet.signAllTransactions(unsignedTxns);
+
+  const pendingTxns= [];
+
+  let breakEarlyObject = { breakEarly: false, i: 0 };
+  console.log(
+    'Signed txns length',
+    signedTxns.length,
+    'vs handed in length',
+    instructionSet.length,
+  );
+  for (let i = 0; i < signedTxns.length; i++) {
+    const signedTxnPromise = sendSignedTransaction({
+      connection,
+      signedTransaction: signedTxns[i],
+    });
+
+    signedTxnPromise
+      .then(({ txid, slot }) => {
+        successCallback(txid, i);
+      })
+      .catch(reason => {
+        failCallback(signedTxns[i], i);
+        if (sequenceType === 'StopOnFailure') {
+          breakEarlyObject.breakEarly = true;
+          breakEarlyObject.i = i;
+        }
+      });
+
+    if (sequenceType !== 'Parallel') {
+      try {
+        await signedTxnPromise;
+      } catch (e) {
+        console.log('Caught failure', e);
+        if (breakEarlyObject.breakEarly) {
+          console.log('Died on ', breakEarlyObject.i);
+          // Return the txn we failed on by index
+          return {
+            number: breakEarlyObject.i,
+            txs: await Promise.all(pendingTxns),
+          };
+        }
+      }
+    } else {
+      pendingTxns.push(signedTxnPromise);
+    }
+  }
+
+  if (sequenceType !== 'Parallel') {
+    await Promise.all(pendingTxns);
+  }
+
+  return { number: signedTxns.length, txs: await Promise.all(pendingTxns) };
+};
+
+export const sendTransaction = async (
+  connection,
+  wallet,
+  instructions,
+  signers,
+  awaitConfirmation = true,
+  commitment = 'singleGossip',
+  includesFeePayer = false,
+  block,
+) => {
+  if (!wallet.publicKey) throw new WalletNotConnectedError();
+
+  let transaction = new Transaction();
+  instructions.forEach(instruction => transaction.add(instruction));
+  transaction.recentBlockhash = (
+    block || (await connection.getRecentBlockhash(commitment))
+  ).blockhash;
+
+  if (includesFeePayer) {
+    transaction.setSigners(...signers.map(s => s.publicKey));
+  } else {
+    transaction.setSigners(
+      // fee payed by the wallet owner
+      wallet.publicKey,
+      ...signers.map(s => s.publicKey),
+    );
+  }
+
+  if (signers.length > 0) {
+    transaction.partialSign(...signers);
+  }
+  if (!includesFeePayer) {
+    transaction = await wallet.signTransaction(transaction);
+  }
+
+  const rawTransaction = transaction.serialize();
+  let options = {
+    skipPreflight: true,
+    commitment,
+  };
+
+  const txid = await connection.sendRawTransaction(rawTransaction, options);
+  let slot = 0;
+
+  if (awaitConfirmation) {
+    const confirmation = await awaitTransactionSignatureConfirmation(
+      txid,
+      DEFAULT_TIMEOUT,
+      connection,
+      commitment,
+    );
+
+    if (!confirmation)
+      throw new Error('Timed out awaiting confirmation on transaction');
+    slot = confirmation?.slot || 0;
+
+    if (confirmation?.err) {
+      const errors = await getErrorForTransaction(connection, txid);
+
+      console.log(errors);
+      throw new Error(`Raw transaction ${txid} failed`);
+    }
+  }
+
+  return { txid, slot };
+};
+
+export const sendTransactionWithRetry = async (
+  connection,
+  wallet,
+  instructions,
+  signers,
+  commitment = 'singleGossip',
+  includesFeePayer = false,
+  block,
+  beforeSend,
+) => {
+  if (!wallet.publicKey) throw new WalletNotConnectedError();
+
+  let transaction = new Transaction();
+  instructions.forEach(instruction => transaction.add(instruction));
+  transaction.recentBlockhash = (
+    block || (await connection.getRecentBlockhash(commitment))
+  ).blockhash;
+
+  if (includesFeePayer) {
+    transaction.setSigners(...signers.map(s => s.publicKey));
+  } else {
+    transaction.setSigners(
+      // fee payed by the wallet owner
+      wallet.publicKey,
+      ...signers.map(s => s.publicKey),
+    );
+  }
+
+  if (signers.length > 0) {
+    transaction.partialSign(...signers);
+  }
+  if (!includesFeePayer) {
+    transaction = await wallet.signTransaction(transaction);
+  }
+
+  if (beforeSend) {
+    beforeSend();
+  }
+
+  const { txid, slot } = await sendSignedTransaction({
+    connection,
+    signedTransaction: transaction,
+  });
+
+  return { txid, slot };
+};
+
+export const getUnixTs = () => {
+  return new Date().getTime() / 1000;
+};
+
+const DEFAULT_TIMEOUT = 15000;
+
+export async function sendSignedTransaction({
+  signedTransaction,
+  connection,
+  timeout = DEFAULT_TIMEOUT,
+}) {
+  const rawTransaction = signedTransaction.serialize();
+  const startTime = getUnixTs();
+  let slot = 0;
+  const txid = await connection.sendRawTransaction(
+    rawTransaction,
+    {
+      skipPreflight: true,
+    },
+  );
+
+  console.log('Started awaiting confirmation for', txid);
+
+  let done = false;
+  (async () => {
+    while (!done && getUnixTs() - startTime < timeout) {
+      connection.sendRawTransaction(rawTransaction, {
+        skipPreflight: true,
+      });
+      await sleep(500);
+    }
+  })();
+  try {
+    const confirmation = await awaitTransactionSignatureConfirmation(
+      txid,
+      timeout,
+      connection,
+      'recent',
+      true,
+    );
+
+    if (!confirmation)
+      throw new Error('Timed out awaiting confirmation on transaction');
+
+    if (confirmation.err) {
+      console.error(confirmation.err);
+      throw new Error('Transaction failed: Custom instruction error');
+    }
+
+    slot = confirmation?.slot || 0;
+  } catch (err) {
+    console.error('Timeout Error caught', err);
+    if (err.timeout) {
+      throw new Error('Timed out awaiting confirmation on transaction');
+    }
+    let simulateResult = null;
+    try {
+      simulateResult = (
+        await simulateTransaction(connection, signedTransaction, 'single')
+      ).value;
+    } catch (e) {}
+    if (simulateResult && simulateResult.err) {
+      if (simulateResult.logs) {
+        for (let i = simulateResult.logs.length - 1; i >= 0; --i) {
+          const line = simulateResult.logs[i];
+          if (line.startsWith('Program log: ')) {
+            throw new Error(
+              'Transaction failed: ' + line.slice('Program log: '.length),
+            );
+          }
+        }
+      }
+      throw new Error(JSON.stringify(simulateResult.err));
+    }
+    // throw new Error('Transaction failed');
+  } finally {
+    done = true;
+  }
+
+  console.log('Latency', txid, getUnixTs() - startTime);
+  return { txid, slot };
+}
+
+async function simulateTransaction(
+  connection,
+  transaction,
+  commitment,
+) {
+  // @ts-ignore
+  transaction.recentBlockhash = await connection._recentBlockhash(
+    // @ts-ignore
+    connection._disableBlockhashCaching,
+  );
+
+  const signData = transaction.serializeMessage();
+  // @ts-ignore
+  const wireTransaction = transaction._serialize(signData);
+  const encodedTransaction = wireTransaction.toString('base64');
+  const config = { encoding: 'base64', commitment };
+  const args = [encodedTransaction, config];
+
+  // @ts-ignore
+  const res = await connection._rpcRequest('simulateTransaction', args);
+  if (res.error) {
+    throw new Error('failed to simulate transaction: ' + res.error.message);
+  }
+  return res.result;
+}
+
+async function awaitTransactionSignatureConfirmation(
+  txid,
+  timeout,
+  connection,
+  commitment = 'recent',
+  queryStatus = false,
+){
+  let done = false;
+  let status = {
+    slot: 0,
+    confirmations: 0,
+    err: null,
+  };
+  let subId = 0;
+  status = await new Promise(async (resolve, reject) => {
+    setTimeout(() => {
+      if (done) {
+        return;
+      }
+      done = true;
+      console.log('Rejecting for timeout...');
+      reject({ timeout: true });
+    }, timeout);
+    try {
+      subId = connection.onSignature(
+        txid,
+        (result, context) => {
+          done = true;
+          status = {
+            err: result.err,
+            slot: context.slot,
+            confirmations: 0,
+          };
+          if (result.err) {
+            console.log('Rejected via websocket', result.err);
+            reject(status);
+          } else {
+            console.log('Resolved via websocket', result);
+            resolve(status);
+          }
+        },
+        commitment,
+      );
+    } catch (e) {
+      done = true;
+      console.error('WS error in setup', txid, e);
+    }
+    while (!done && queryStatus) {
+      // eslint-disable-next-line no-loop-func
+      (async () => {
+        try {
+          const signatureStatuses = await connection.getSignatureStatuses([
+            txid,
+          ]);
+          status = signatureStatuses && signatureStatuses.value[0];
+          if (!done) {
+            if (!status) {
+              console.log('REST null result for', txid, status);
+            } else if (status.err) {
+              console.log('REST error for', txid, status);
+              done = true;
+              reject(status.err);
+            } else if (!status.confirmations) {
+              console.log('REST no confirmations for', txid, status);
+            } else {
+              console.log('REST confirmation for', txid, status);
+              done = true;
+              resolve(status);
+            }
+          }
+        } catch (e) {
+          if (!done) {
+            console.log('REST connection error: txid', txid, e);
+          }
+        }
+      })();
+      await sleep(2000);
+    }
+  });
+
+  //@ts-ignore
+  if (connection._signatureSubscriptions[subId])
+    connection.removeSignatureListener(subId);
+  done = true;
+  console.log('Returning status', status);
+  return status;
+}
+export function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/app/src/CandyMachine/helpers.js
+++ b/app/src/CandyMachine/helpers.js
@@ -1,8 +1,16 @@
 import { web3 } from '@project-serum/anchor';
+import * as anchor from '@project-serum/anchor';
+import { TOKEN_PROGRAM_ID } from '@solana/spl-token';
+import { SystemProgram } from '@solana/web3.js';
+import {
+  LAMPORTS_PER_SOL,
+  SYSVAR_RENT_PUBKEY,
+  TransactionInstruction,
+} from '@solana/web3.js';
 
 // CLI Properties Given to us
 const candyMachineProgram = new web3.PublicKey(
-  'cndyAnrLdpjq1Ssp1z8xxDsB8dxe7u4HL5Nxi2K5WXZ'
+  'cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ'
 );
 
 const TOKEN_METADATA_PROGRAM_ID = new web3.PublicKey(
@@ -12,8 +20,127 @@ const TOKEN_METADATA_PROGRAM_ID = new web3.PublicKey(
 const SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID = new web3.PublicKey(
   'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'
 );
+
+const CIVIC = new anchor.web3.PublicKey(
+  'gatem74V238djXdzWnJf94Wo1DcnuGkfijbf3AuBhfs',
+);
+
+const toDate = (value) => {
+  if (!value) {
+    return;
+  }
+
+  return new Date(value.toNumber() * 1000);
+};
+
+const numberFormater = new Intl.NumberFormat('en-US', {
+  style: 'decimal',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const formatNumber = {
+  format: (val) => {
+    if (!val) {
+      return '--';
+    }
+
+    return numberFormater.format(val);
+  },
+  asNumber: (val) => {
+    if (!val) {
+      return undefined;
+    }
+
+    return val.toNumber() / LAMPORTS_PER_SOL;
+  },
+};
+
+const getAtaForMint = async (mint, buyer)=> {
+  return await anchor.web3.PublicKey.findProgramAddress(
+    [buyer.toBuffer(), TOKEN_PROGRAM_ID.toBuffer(), mint.toBuffer()],
+    SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID,
+  );
+};
+
+const getNetworkExpire = async (gatekeeperNetwork) => {
+  return await anchor.web3.PublicKey.findProgramAddress(
+    [gatekeeperNetwork.toBuffer(), Buffer.from('expire')],
+    CIVIC,
+  );
+};
+
+const getNetworkToken = async (wallet, gatekeeperNetwork) => {
+  return await anchor.web3.PublicKey.findProgramAddress(
+    [
+      wallet.toBuffer(),
+      Buffer.from('gateway'),
+      Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]),
+      gatekeeperNetwork.toBuffer(),
+    ],
+    CIVIC,
+  );
+};
+
+function createAssociatedTokenAccountInstruction(
+  associatedTokenAddress,
+  payer,
+  walletAddress,
+  splTokenMintAddress,
+) {
+  const keys = [
+    {
+      pubkey: payer,
+      isSigner: true,
+      isWritable: true,
+    },
+    {
+      pubkey: associatedTokenAddress,
+      isSigner: false,
+      isWritable: true,
+    },
+    {
+      pubkey: walletAddress,
+      isSigner: false,
+      isWritable: false,
+    },
+    {
+      pubkey: splTokenMintAddress,
+      isSigner: false,
+      isWritable: false,
+    },
+    {
+      pubkey: SystemProgram.programId,
+      isSigner: false,
+      isWritable: false,
+    },
+    {
+      pubkey: TOKEN_PROGRAM_ID,
+      isSigner: false,
+      isWritable: false,
+    },
+    {
+      pubkey: SYSVAR_RENT_PUBKEY,
+      isSigner: false,
+      isWritable: false,
+    },
+  ];
+  return new TransactionInstruction({
+    keys,
+    programId: SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID,
+    data: Buffer.from([]),
+  });
+}
+
 export {
   candyMachineProgram,
   TOKEN_METADATA_PROGRAM_ID,
   SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID,
+  CIVIC,
+  toDate,
+  formatNumber,
+  getAtaForMint,
+  getNetworkExpire,
+  getNetworkToken,
+  createAssociatedTokenAccountInstruction,
 };

--- a/app/src/CandyMachine/index.js
+++ b/app/src/CandyMachine/index.js
@@ -2,73 +2,49 @@ import React from 'react';
 import { Connection, PublicKey } from '@solana/web3.js';
 import { Program, Provider, web3 } from '@project-serum/anchor';
 import { MintLayout, TOKEN_PROGRAM_ID, Token } from '@solana/spl-token';
+import { sendTransactions } from './connection';
 import { programs } from '@metaplex/js';
 import './CandyMachine.css';
 import {
   candyMachineProgram,
   TOKEN_METADATA_PROGRAM_ID,
   SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID,
+  getAtaForMint,
+  getNetworkExpire,
+  getNetworkToken,
+  CIVIC
 } from './helpers';
-const {
-  metadata: { Metadata, MetadataProgram },
-} = programs;
 
-const config = new web3.PublicKey(process.env.REACT_APP_CANDY_MACHINE_CONFIG);
 const { SystemProgram } = web3;
 const opts = {
   preflightCommitment: 'processed',
 };
 
-const MAX_NAME_LENGTH = 32;
-const MAX_URI_LENGTH = 200;
-const MAX_SYMBOL_LENGTH = 10;
-const MAX_CREATOR_LEN = 32 + 1 + 1;
-
 const CandyMachine = ({ walletAddress }) => {
-  // Actions
-  const fetchHashTable = async (hash, metadataEnabled) => {
-    const connection = new web3.Connection(
-      process.env.REACT_APP_SOLANA_RPC_HOST
-    );
 
-    const metadataAccounts = await MetadataProgram.getProgramAccounts(
-      connection,
-      {
-        filters: [
-          {
-            memcmp: {
-              offset:
-                1 +
-                32 +
-                32 +
-                4 +
-                MAX_NAME_LENGTH +
-                4 +
-                MAX_URI_LENGTH +
-                4 +
-                MAX_SYMBOL_LENGTH +
-                2 +
-                1 +
-                4 +
-                0 * MAX_CREATOR_LEN,
-              bytes: hash,
-            },
-          },
-        ],
-      }
-    );
-
-    const mintHashes = [];
-
-    for (let index = 0; index < metadataAccounts.length; index++) {
-      const account = metadataAccounts[index];
-      const accountInfo = await connection.getParsedAccountInfo(account.pubkey);
-      const metadata = new Metadata(hash.toString(), accountInfo.value);
-      if (metadataEnabled) mintHashes.push(metadata.data);
-      else mintHashes.push(metadata.data.mint);
+  const wallet = useMemo(() => {
+    if(
+      !walletAddress ||
+      !walletAddress.publicKey ||
+      !walletAddress.signAllTransactions ||
+      !walletAddress.signTransaction
+    ){
+      return;
     }
 
-    return mintHashes;
+    return {
+      publicKey: walletAddress.publicKey,
+      signAllTransactions: walletAddress.signAllTransactions,
+      signTransaction: walletAddress.signTransaction,
+    }
+  }, [walletAddress]);
+  
+  const getCandyMachineCreator = async (candyMachine) => {
+    const candyMachineID = new PublicKey(candyMachine);
+    return await web3.PublicKey.findProgramAddress(
+        [Buffer.from('candy_machine'), candyMachineID.toBuffer()],
+        candyMachineProgram,
+    );
   };
 
   const getMetadata = async (mint) => {
@@ -96,128 +72,6 @@ const CandyMachine = ({ walletAddress }) => {
         TOKEN_METADATA_PROGRAM_ID
       )
     )[0];
-  };
-
-  const getTokenWallet = async (wallet, mint) => {
-    return (
-      await web3.PublicKey.findProgramAddress(
-        [wallet.toBuffer(), TOKEN_PROGRAM_ID.toBuffer(), mint.toBuffer()],
-        SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID
-      )
-    )[0];
-  };
-
-  const mintToken = async () => {
-    try {
-      const mint = web3.Keypair.generate();
-      const token = await getTokenWallet(
-        walletAddress.publicKey,
-        mint.publicKey
-      );
-      const metadata = await getMetadata(mint.publicKey);
-      const masterEdition = await getMasterEdition(mint.publicKey);
-      const rpcHost = process.env.REACT_APP_SOLANA_RPC_HOST;
-      const connection = new Connection(rpcHost);
-      const rent = await connection.getMinimumBalanceForRentExemption(
-        MintLayout.span
-      );
-
-      const accounts = {
-        config,
-        candyMachine: process.env.REACT_APP_CANDY_MACHINE_ID,
-        payer: walletAddress.publicKey,
-        wallet: process.env.REACT_APP_TREASURY_ADDRESS,
-        mint: mint.publicKey,
-        metadata,
-        masterEdition,
-        mintAuthority: walletAddress.publicKey,
-        updateAuthority: walletAddress.publicKey,
-        tokenMetadataProgram: TOKEN_METADATA_PROGRAM_ID,
-        tokenProgram: TOKEN_PROGRAM_ID,
-        systemProgram: SystemProgram.programId,
-        rent: web3.SYSVAR_RENT_PUBKEY,
-        clock: web3.SYSVAR_CLOCK_PUBKEY,
-      };
-
-      const signers = [mint];
-      const instructions = [
-        web3.SystemProgram.createAccount({
-          fromPubkey: walletAddress.publicKey,
-          newAccountPubkey: mint.publicKey,
-          space: MintLayout.span,
-          lamports: rent,
-          programId: TOKEN_PROGRAM_ID,
-        }),
-        Token.createInitMintInstruction(
-          TOKEN_PROGRAM_ID,
-          mint.publicKey,
-          0,
-          walletAddress.publicKey,
-          walletAddress.publicKey
-        ),
-        createAssociatedTokenAccountInstruction(
-          token,
-          walletAddress.publicKey,
-          walletAddress.publicKey,
-          mint.publicKey
-        ),
-        Token.createMintToInstruction(
-          TOKEN_PROGRAM_ID,
-          mint.publicKey,
-          token,
-          walletAddress.publicKey,
-          [],
-          1
-        ),
-      ];
-
-      const provider = getProvider();
-      const idl = await Program.fetchIdl(candyMachineProgram, provider);
-      const program = new Program(idl, candyMachineProgram, provider);
-
-      const txn = await program.rpc.mintNft({
-        accounts,
-        signers,
-        instructions,
-      });
-
-      console.log('txn:', txn);
-
-      // Setup listener
-      connection.onSignatureWithOptions(
-        txn,
-        async (notification, context) => {
-          if (notification.type === 'status') {
-            console.log('Receievd status event');
-
-            const { result } = notification;
-            if (!result.err) {
-              console.log('NFT Minted!');
-            }
-          }
-        },
-        { commitment: 'processed' }
-      );
-    } catch (error) {
-      let message = error.msg || 'Minting failed! Please try again!';
-
-      if (!error.msg) {
-        if (error.message.indexOf('0x138')) {
-        } else if (error.message.indexOf('0x137')) {
-          message = `SOLD OUT!`;
-        } else if (error.message.indexOf('0x135')) {
-          message = `Insufficient funds to mint. Please fund your wallet.`;
-        }
-      } else {
-        if (error.code === 311) {
-          message = `SOLD OUT!`;
-        } else if (error.code === 312) {
-          message = `Minting period hasn't started yet.`;
-        }
-      }
-
-      console.warn(message);
-    }
   };
 
   const createAssociatedTokenAccountInstruction = (
@@ -248,6 +102,217 @@ const CandyMachine = ({ walletAddress }) => {
       programId: SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID,
       data: Buffer.from([]),
     });
+  };
+
+  const mintToken = async () => {
+    const mint = web3.Keypair.generate();
+
+    const userTokenAccountAddress = (
+      await getAtaForMint(mint.publicKey, walletAddress.publicKey)
+    )[0];
+  
+    const userPayingAccountAddress = candyMachine.state.tokenMint
+      ? (await getAtaForMint(candyMachine.state.tokenMint, walletAddress.publicKey))[0]
+      : walletAddress.publicKey;
+  
+    const candyMachineAddress = candyMachine.id;
+    const remainingAccounts = [];
+    const signers = [mint];
+    const cleanupInstructions = [];
+    const instructions = [
+      web3.SystemProgram.createAccount({
+        fromPubkey: walletAddress.publicKey,
+        newAccountPubkey: mint.publicKey,
+        space: MintLayout.span,
+        lamports:
+          await candyMachine.program.provider.connection.getMinimumBalanceForRentExemption(
+            MintLayout.span,
+          ),
+        programId: TOKEN_PROGRAM_ID,
+      }),
+      Token.createInitMintInstruction(
+        TOKEN_PROGRAM_ID,
+        mint.publicKey,
+        0,
+        walletAddress.publicKey,
+        walletAddress.publicKey,
+      ),
+      createAssociatedTokenAccountInstruction(
+        userTokenAccountAddress,
+        walletAddress.publicKey,
+        walletAddress.publicKey,
+        mint.publicKey,
+      ),
+      Token.createMintToInstruction(
+        TOKEN_PROGRAM_ID,
+        mint.publicKey,
+        userTokenAccountAddress,
+        walletAddress.publicKey,
+        [],
+        1,
+      ),
+    ];
+  
+    if (candyMachine.state.gatekeeper) {
+      remainingAccounts.push({
+        pubkey: (
+          await getNetworkToken(
+            walletAddress.publicKey,
+            candyMachine.state.gatekeeper.gatekeeperNetwork,
+          )
+        )[0],
+        isWritable: true,
+        isSigner: false,
+      });
+      if (candyMachine.state.gatekeeper.expireOnUse) {
+        remainingAccounts.push({
+          pubkey: CIVIC,
+          isWritable: false,
+          isSigner: false,
+        });
+        remainingAccounts.push({
+          pubkey: (
+            await getNetworkExpire(
+              candyMachine.state.gatekeeper.gatekeeperNetwork,
+            )
+          )[0],
+          isWritable: false,
+          isSigner: false,
+        });
+      }
+    }
+    if (candyMachine.state.whitelistMintSettings) {
+      const mint = new web3.PublicKey(
+        candyMachine.state.whitelistMintSettings.mint,
+      );
+  
+      const whitelistToken = (await getAtaForMint(mint, walletAddress.publicKey))[0];
+      remainingAccounts.push({
+        pubkey: whitelistToken,
+        isWritable: true,
+        isSigner: false,
+      });
+  
+      if (candyMachine.state.whitelistMintSettings.mode.burnEveryTime) {
+        const whitelistBurnAuthority = web3.Keypair.generate();
+  
+        remainingAccounts.push({
+          pubkey: mint,
+          isWritable: true,
+          isSigner: false,
+        });
+        remainingAccounts.push({
+          pubkey: whitelistBurnAuthority.publicKey,
+          isWritable: false,
+          isSigner: true,
+        });
+        signers.push(whitelistBurnAuthority);
+        const exists =
+          await candyMachine.program.provider.connection.getAccountInfo(
+            whitelistToken,
+          );
+        if (exists) {
+          instructions.push(
+            Token.createApproveInstruction(
+              TOKEN_PROGRAM_ID,
+              whitelistToken,
+              whitelistBurnAuthority.publicKey,
+              walletAddress.publicKey,
+              [],
+              1,
+            ),
+          );
+          cleanupInstructions.push(
+            Token.createRevokeInstruction(
+              TOKEN_PROGRAM_ID,
+              whitelistToken,
+              walletAddress.publicKey,
+              [],
+            ),
+          );
+        }
+      }
+    }
+  
+    if (candyMachine.state.tokenMint) {
+      const transferAuthority = web3.Keypair.generate();
+  
+      signers.push(transferAuthority);
+      remainingAccounts.push({
+        pubkey: userPayingAccountAddress,
+        isWritable: true,
+        isSigner: false,
+      });
+      remainingAccounts.push({
+        pubkey: transferAuthority.publicKey,
+        isWritable: false,
+        isSigner: true,
+      });
+  
+      instructions.push(
+        Token.createApproveInstruction(
+          TOKEN_PROGRAM_ID,
+          userPayingAccountAddress,
+          transferAuthority.publicKey,
+          walletAddress.publicKey,
+          [],
+          candyMachine.state.price.toNumber(),
+        ),
+      );
+      cleanupInstructions.push(
+        Token.createRevokeInstruction(
+          TOKEN_PROGRAM_ID,
+          userPayingAccountAddress,
+          walletAddress.publicKey,
+          [],
+        ),
+      );
+    }
+    const metadataAddress = await getMetadata(mint.publicKey);
+    const masterEdition = await getMasterEdition(mint.publicKey);
+  
+    const [candyMachineCreator, creatorBump] = await getCandyMachineCreator(
+      candyMachineAddress,
+    );
+  
+    instructions.push(
+      await candyMachine.program.instruction.mintNft(creatorBump, {
+        accounts: {
+          candyMachine: candyMachineAddress,
+          candyMachineCreator,
+          payer: walletAddress.publicKey,
+          wallet: candyMachine.state.treasury,
+          mint: mint.publicKey,
+          metadata: metadataAddress,
+          masterEdition,
+          mintAuthority: walletAddress.publicKey,
+          updateAuthority: walletAddress.publicKey,
+          tokenMetadataProgram: TOKEN_METADATA_PROGRAM_ID,
+          tokenProgram: TOKEN_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+          rent: web3.SYSVAR_RENT_PUBKEY,
+          clock: web3.SYSVAR_CLOCK_PUBKEY,
+          recentBlockhashes: web3.SYSVAR_RECENT_BLOCKHASHES_PUBKEY,
+          instructionSysvarAccount: web3.SYSVAR_INSTRUCTIONS_PUBKEY,
+        },
+        remainingAccounts:
+          remainingAccounts.length > 0 ? remainingAccounts : undefined,
+      }),
+    );
+  
+    try {
+      return (
+        await sendTransactions(
+          candyMachine.program.provider.connection,
+          candyMachine.program.provider.wallet,
+          [instructions, cleanupInstructions],
+          [signers, []],
+        )
+      ).txs.map(t => t.txid);
+    } catch (e) {
+      console.log(e);
+    }
+    return [];
   };
 
   return (

--- a/app/src/CandyMachine/index.js
+++ b/app/src/CandyMachine/index.js
@@ -22,23 +22,6 @@ const opts = {
 
 const CandyMachine = ({ walletAddress }) => {
 
-  const wallet = useMemo(() => {
-    if(
-      !walletAddress ||
-      !walletAddress.publicKey ||
-      !walletAddress.signAllTransactions ||
-      !walletAddress.signTransaction
-    ){
-      return;
-    }
-
-    return {
-      publicKey: walletAddress.publicKey,
-      signAllTransactions: walletAddress.signAllTransactions,
-      signTransaction: walletAddress.signTransaction,
-    }
-  }, [walletAddress]);
-  
   const getCandyMachineCreator = async (candyMachine) => {
     const candyMachineID = new PublicKey(candyMachine);
     return await web3.PublicKey.findProgramAddress(


### PR DESCRIPTION
# Changes made:
### Added **connection.js**
Copied from https://github.com/metaplex-foundation/metaplex/blob/master/js/packages/candy-machine-ui/src/connection.tsx and converted to JS. This is necessary to create the mint transaction for the v2 mint function. I couldn't figure out how Farza has the v1 tx setup done so I've just ported over the process from the official template.

### Update CMV2 program address and add utils to **helpers.js** 
Same as above, copied over utils from https://github.com/metaplex-foundation/metaplex/blob/master/js/packages/candy-machine-ui/src/utils.ts as they're needed by the mint and other helpers.

### Update CandyMachine/index.js
1. Removed fetchHashTable and all relevant code for fetching minted NFTs. fetchHashTable is broken on V2 and our old process for fetching mints no longer works. Removing this from the project for the time being, will create a PR later adding it back in using an updated process.
2. Import helpers and utils.
3. Replace mintToken function: the new one is copied from https://github.com/metaplex-foundation/metaplex/blob/master/js/packages/candy-machine-ui/src/utils.ts and adapted to our setup to run without any arguments.  The core logic is ported over 1:1. It is missing the post transaction connection listener that v1 uses to [log mint events](https://github.com/buildspace/nft-drop-starter-project/pull/23/files#diff-844287216e035ba7e415c9c6cc947f721dec11115702bed92d5df4b291fa536bL187). Can add back in when/if I figure out how to do so.

# Known issues
Since there's nothing listening for a mint event, there's no way to update UI components to reflect minting status/available mints. This breaks:
 1. Mint button isn't disabled during minting
 2. Mint count doesn't update after minting